### PR TITLE
Redesign frontend: white theme, football hero, professional typography

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,11 +4,18 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hair Length Index — Eredivisie</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Playfair+Display:wght@700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header>
-    <div class="header-content">
+  <header class="hero">
+    <video class="hero-video" autoplay muted loop playsinline poster="https://images.unsplash.com/photo-1489944440615-453fc2b6a9a9?w=1600&q=80">
+      <source src="https://cdn.coverr.co/videos/coverr-football-match-2743/1080p.mp4" type="video/mp4">
+    </video>
+    <div class="hero-overlay"></div>
+    <div class="hero-content">
       <h1>Hair Length Index</h1>
       <p class="subtitle">Hoelang geleden won jouw club 5x op een rij?</p>
     </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -6,65 +6,102 @@
 }
 
 :root {
-  --bg: #0f1118;
-  --bg-card: #1a1d2b;
-  --bg-card-hover: #222639;
-  --text: #e8e8ed;
-  --text-muted: #8b8fa3;
-  --accent: #f0c040;
-  --green: #4ade80;
-  --red: #f87171;
-  --draw: #a3a3a3;
-  --border: #2a2e3f;
-  --radius: 12px;
+  --bg: #ffffff;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f8faf8;
+  --text: #1a1a2e;
+  --text-muted: #6b7280;
+  --accent: #16a34a;
+  --accent-dark: #15803d;
+  --green: #16a34a;
+  --red: #dc2626;
+  --draw: #9ca3af;
+  --border: #e5e7eb;
+  --border-hover: #d1d5db;
+  --radius: 10px;
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
 
-  /* tier colors */
-  --tier-fresh: #4ade80;
-  --tier-growing: #a3e635;
-  --tier-shaggy: #facc15;
-  --tier-wild: #fb923c;
-  --tier-caveman: #f87171;
-  --tier-sasquatch: #c084fc;
-  --tier-lost: #64748b;
+  /* tier colors — muted, professional palette */
+  --tier-fresh: #16a34a;
+  --tier-growing: #65a30d;
+  --tier-shaggy: #ca8a04;
+  --tier-wild: #ea580c;
+  --tier-caveman: #dc2626;
+  --tier-sasquatch: #9333ea;
+  --tier-lost: #6b7280;
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   background: var(--bg);
   color: var(--text);
-  line-height: 1.5;
+  line-height: 1.6;
   min-height: 100vh;
 }
 
-/* === Header === */
-header {
-  background: linear-gradient(135deg, #1a1d2b 0%, #2a1a3a 100%);
-  border-bottom: 1px solid var(--border);
-  padding: 2rem 1rem;
-  text-align: center;
+/* === Hero Header === */
+.hero {
+  position: relative;
+  height: 400px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.header-content h1 {
-  font-size: 2.5rem;
-  font-weight: 800;
+.hero-video {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  min-width: 100%;
+  min-height: 100%;
+  transform: translate(-50%, -50%);
+  object-fit: cover;
+  z-index: 0;
+}
+
+.hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 40, 20, 0.65) 0%,
+    rgba(0, 20, 10, 0.80) 100%
+  );
+  z-index: 1;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.hero-content h1 {
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: 3.5rem;
+  font-weight: 900;
+  color: #ffffff;
   letter-spacing: -0.02em;
-  background: linear-gradient(135deg, var(--accent) 0%, #f09040 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  line-height: 1.1;
+  text-shadow: 0 2px 20px rgba(0, 0, 0, 0.3);
 }
 
 .subtitle {
-  color: var(--text-muted);
-  font-size: 1.1rem;
-  margin-top: 0.5rem;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1.15rem;
+  font-weight: 400;
+  margin-top: 0.75rem;
+  letter-spacing: 0.01em;
 }
 
 /* === Main === */
 main {
   max-width: 900px;
   margin: 0 auto;
-  padding: 1.5rem 1rem 3rem;
+  padding: 2rem 1rem 3rem;
 }
 
 /* === Controls === */
@@ -78,13 +115,13 @@ main {
 }
 
 .league-badge {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
   border-radius: 999px;
   padding: 0.4rem 1rem;
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--accent);
+  color: var(--accent-dark);
 }
 
 .updated {
@@ -98,24 +135,25 @@ main {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1rem 1.25rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.6rem;
   display: grid;
-  grid-template-columns: 3rem 3.5rem 1fr auto;
+  grid-template-columns: 2.5rem 3.5rem 1fr auto;
   grid-template-rows: auto auto;
   gap: 0.25rem 1rem;
   align-items: center;
-  transition: background 0.15s, border-color 0.15s;
+  transition: box-shadow 0.2s, border-color 0.2s;
+  box-shadow: var(--shadow-sm);
 }
 
 .team-card:hover {
-  background: var(--bg-card-hover);
-  border-color: #3a3e52;
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-md);
 }
 
 /* Rank */
 .rank {
   grid-row: 1 / 3;
-  font-size: 1.4rem;
+  font-size: 1.3rem;
   font-weight: 800;
   color: var(--text-muted);
   text-align: center;
@@ -128,8 +166,9 @@ main {
   height: 3.5rem;
   border-radius: 50%;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.05);
+  background: #f3f4f6;
   flex-shrink: 0;
+  border: 2px solid var(--border);
 }
 
 .avatar-img {
@@ -147,11 +186,12 @@ main {
 
 .team-name {
   font-weight: 700;
-  font-size: 1.05rem;
+  font-size: 1rem;
+  color: var(--text);
 }
 
 .tier-badge {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   font-weight: 700;
   padding: 0.15rem 0.55rem;
   border-radius: 999px;
@@ -166,7 +206,7 @@ main {
 }
 
 .days-number {
-  font-size: 1.8rem;
+  font-size: 1.7rem;
   font-weight: 800;
   line-height: 1;
 }
@@ -211,12 +251,11 @@ main {
   justify-content: center;
   font-size: 0.55rem;
   font-weight: 800;
-  color: #fff;
 }
 
-.form-dot.W { background: var(--green); color: #052e16; }
-.form-dot.D { background: var(--draw); color: #1a1a1a; }
-.form-dot.L { background: var(--red); color: #450a0a; }
+.form-dot.W { background: #dcfce7; color: #15803d; border: 1px solid #bbf7d0; }
+.form-dot.D { background: #f3f4f6; color: #6b7280; border: 1px solid #e5e7eb; }
+.form-dot.L { background: #fef2f2; color: #dc2626; border: 1px solid #fecaca; }
 
 /* Matches-since (bottom-right) */
 .matches-since {
@@ -237,7 +276,7 @@ main {
   font-size: 0.65rem;
   padding: 0.1rem 0.4rem;
   border-radius: 4px;
-  background: rgba(255, 255, 255, 0.06);
+  background: #f9fafb;
   color: var(--text-muted);
   border: 1px solid var(--border);
 }
@@ -254,15 +293,16 @@ main {
   color: var(--tier-lost);
 }
 
-/* === Tier colors === */
-.tier-fresh      { background: var(--tier-fresh);     color: #052e16; }
-.tier-growing    { background: var(--tier-growing);    color: #1a2e05; }
-.tier-shaggy     { background: var(--tier-shaggy);     color: #422006; }
-.tier-wild       { background: var(--tier-wild);       color: #431407; }
-.tier-caveman    { background: var(--tier-caveman);    color: #450a0a; }
-.tier-sasquatch  { background: var(--tier-sasquatch);  color: #2e1065; }
-.tier-lost       { background: var(--tier-lost);       color: #0f172a; }
+/* === Tier badge colors === */
+.tier-fresh      { background: #dcfce7; color: #15803d; }
+.tier-growing    { background: #ecfccb; color: #3f6212; }
+.tier-shaggy     { background: #fef9c3; color: #854d0e; }
+.tier-wild       { background: #ffedd5; color: #9a3412; }
+.tier-caveman    { background: #fef2f2; color: #b91c1c; }
+.tier-sasquatch  { background: #f3e8ff; color: #7e22ce; }
+.tier-lost       { background: #f3f4f6; color: #4b5563; }
 
+/* Days number colors — slightly bolder for contrast on white */
 .days-fresh      { color: var(--tier-fresh); }
 .days-growing    { color: var(--tier-growing); }
 .days-shaggy     { color: var(--tier-shaggy); }
@@ -285,7 +325,7 @@ footer p { margin-bottom: 0.75rem; }
 
 .footnotes {
   font-size: 0.75rem;
-  color: #555;
+  color: #9ca3af;
 }
 
 /* === Loading === */
@@ -300,14 +340,19 @@ footer p { margin-bottom: 0.75rem; }
   text-align: center;
   padding: 2rem;
   color: var(--red);
-  background: rgba(248, 113, 113, 0.1);
+  background: #fef2f2;
+  border: 1px solid #fecaca;
   border-radius: var(--radius);
 }
 
 /* === Responsive === */
 @media (max-width: 600px) {
-  .header-content h1 {
-    font-size: 1.8rem;
+  .hero {
+    height: 280px;
+  }
+
+  .hero-content h1 {
+    font-size: 2.2rem;
   }
 
   .subtitle {
@@ -315,7 +360,7 @@ footer p { margin-bottom: 0.75rem; }
   }
 
   .team-card {
-    grid-template-columns: 2.2rem 2.8rem 1fr auto;
+    grid-template-columns: 2rem 2.8rem 1fr auto;
     padding: 0.8rem 0.75rem;
     gap: 0.2rem 0.6rem;
   }
@@ -330,11 +375,11 @@ footer p { margin-bottom: 0.75rem; }
   }
 
   .team-name {
-    font-size: 0.95rem;
+    font-size: 0.9rem;
   }
 
   .days-number {
-    font-size: 1.4rem;
+    font-size: 1.3rem;
   }
 
   .tier-badge {


### PR DESCRIPTION
Replace dark gaming-style theme with clean white background, Inter + Playfair Display fonts, muted tier colors for light backgrounds, and a hero section with football stadium video/poster image with dark overlay.

https://claude.ai/code/session_0173ybHT6QAFjoxLHGyNNkD2